### PR TITLE
Patches to transferStackInSlot methods

### DIFF
--- a/src/main/java/com/theundertaker11/geneticsreborn/blocks/bloodpurifier/ContainerBloodPurifier.java
+++ b/src/main/java/com/theundertaker11/geneticsreborn/blocks/bloodpurifier/ContainerBloodPurifier.java
@@ -69,33 +69,40 @@ public class ContainerBloodPurifier extends Container {
 	}
 
 	@Override
-	public ItemStack transferStackInSlot(EntityPlayer player, int sourceSlotIndex) {
-		Slot slot = (Slot) this.inventorySlots.get(sourceSlotIndex);
-		if (slot == null || !slot.getHasStack()) return ItemStack.EMPTY;
-		if (tileInventory.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, EnumFacing.UP) == null)
-			return ItemStack.EMPTY;
-		IItemHandler input = tileInventory.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, EnumFacing.UP);
+	public ItemStack transferStackInSlot(EntityPlayer playerIn, int index){
+		ItemStack itemstack = ItemStack.EMPTY;
+		Slot slot = this.inventorySlots.get(index);
 
-		ItemStack sourceStack = slot.getStack();
-		ItemStack copyOfStack = sourceStack.copy();
-
-		if (sourceSlotIndex >= VANILLA_FIRST_SLOT_INDEX && sourceSlotIndex < VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT) {
-			if ((sourceStack.getItem() == GRItems.GlassSyringe || sourceStack.getItem() == GRItems.MetalSyringe) && sourceStack.getItemDamage() == 1) {
-				if (input.insertItem(0, sourceStack, true).isEmpty()) {
-					input.insertItem(0, sourceStack, false);
-					player.inventory.setInventorySlotContents(sourceSlotIndex, ItemStack.EMPTY);
-				} else if (input.insertItem(0, sourceStack, true).getCount() == sourceStack.getCount()) {
-					return ItemStack.EMPTY;
-				} else {
-					player.inventory.setInventorySlotContents(sourceSlotIndex, input.insertItem(0, sourceStack, false));
+		if(slot != null && slot.getHasStack()){ //Checks that slot is valid and has items in it.
+			ItemStack itemstack1 = slot.getStack();
+			itemstack = itemstack1.copy();
+			if(index <= 35){
+				if(slot.getStack().getItem()== GRItems.GlassSyringe || slot.getStack().getItem() == GRItems.MetalSyringe && itemstack1.getItemDamage() == 1){
+					if (!this.mergeItemStack(slot.getStack(), 36, 37, false)) {
+						this.mergeItemStack(slot.getStack(), 36, 37,false);
+						return ItemStack.EMPTY;
+					}
+					else{
+						return itemstack;
+					}
 				}
-			} else return ItemStack.EMPTY;
-		} else if (sourceSlotIndex == INPUT_SLOT_INDEX || sourceSlotIndex == OUTPUT_SLOT_INDEX) {
-			if (!this.mergeItemStack(sourceStack, VANILLA_FIRST_SLOT_INDEX, VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT, false)) {
+			} else if (!this.mergeItemStack(itemstack1, 0, 37, false)) {
 				return ItemStack.EMPTY;
 			}
-		} else return ItemStack.EMPTY;
-		return copyOfStack;
+
+			if (itemstack1.isEmpty()) {
+				slot.putStack(ItemStack.EMPTY);
+			} else {
+				slot.onSlotChanged();
+			}
+
+			if (itemstack1.getCount() == itemstack.getCount()) {
+				return ItemStack.EMPTY;
+			}
+
+			slot.onTake(playerIn, itemstack1);
+		}
+		return itemstack;
 	}
 
 	@Override

--- a/src/main/java/com/theundertaker11/geneticsreborn/blocks/cellanalyser/ContainerCellAnalyser.java
+++ b/src/main/java/com/theundertaker11/geneticsreborn/blocks/cellanalyser/ContainerCellAnalyser.java
@@ -7,8 +7,6 @@ import net.minecraft.inventory.Container;
 import net.minecraft.inventory.IContainerListener;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.FurnaceRecipes;
-import net.minecraft.tileentity.TileEntityFurnace;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;

--- a/src/main/java/com/theundertaker11/geneticsreborn/blocks/cellanalyser/ContainerCellAnalyser.java
+++ b/src/main/java/com/theundertaker11/geneticsreborn/blocks/cellanalyser/ContainerCellAnalyser.java
@@ -7,6 +7,8 @@ import net.minecraft.inventory.Container;
 import net.minecraft.inventory.IContainerListener;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.FurnaceRecipes;
+import net.minecraft.tileentity.TileEntityFurnace;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -69,33 +71,40 @@ public class ContainerCellAnalyser extends Container {
 	}
 
 	@Override
-	public ItemStack transferStackInSlot(EntityPlayer player, int sourceSlotIndex) {
-		Slot slot = (Slot) this.inventorySlots.get(sourceSlotIndex);
-		if (slot == null || !slot.getHasStack()) return ItemStack.EMPTY;
-		if (tileInventory.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, EnumFacing.UP) == null)
-			return ItemStack.EMPTY;
-		IItemHandler input = tileInventory.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, EnumFacing.UP);
+	public ItemStack transferStackInSlot(EntityPlayer playerIn, int index){
+		ItemStack itemstack = ItemStack.EMPTY;
+		Slot slot = this.inventorySlots.get(index);
 
-		ItemStack sourceStack = slot.getStack();
-		ItemStack copyOfStack = sourceStack.copy();
-
-		if (sourceSlotIndex >= VANILLA_FIRST_SLOT_INDEX && sourceSlotIndex < VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT) {
-			if (sourceStack.getItem() == GRItems.OrganicMatter) {
-				if (input.insertItem(0, sourceStack, true).isEmpty()) {
-					input.insertItem(0, sourceStack, false);
-					player.inventory.setInventorySlotContents(sourceSlotIndex, ItemStack.EMPTY);
-				} else if (input.insertItem(0, sourceStack, true).getCount() == sourceStack.getCount()) {
-					return ItemStack.EMPTY;
-				} else {
-					player.inventory.setInventorySlotContents(sourceSlotIndex, input.insertItem(0, sourceStack, false));
+		if(slot != null && slot.getHasStack()){ //Checks that slot is valid and has items in it.
+			ItemStack itemstack1 = slot.getStack();
+			itemstack = itemstack1.copy();
+			if(index <= 35){
+				if(slot.getStack().getItem()== GRItems.OrganicMatter){
+					if (!this.mergeItemStack(slot.getStack(), 36, 37, false)) {
+						this.mergeItemStack(slot.getStack(), 36, 37,false);
+						return ItemStack.EMPTY;
+					}
+					else{
+						return itemstack;
+					}
 				}
-			} else return ItemStack.EMPTY;
-		} else if (sourceSlotIndex == INPUT_SLOT_INDEX || sourceSlotIndex == OUTPUT_SLOT_INDEX) {
-			if (!this.mergeItemStack(sourceStack, VANILLA_FIRST_SLOT_INDEX, VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT, false)) {
+			} else if (!this.mergeItemStack(itemstack1, 0, 37, false)) {
 				return ItemStack.EMPTY;
 			}
-		} else return ItemStack.EMPTY;
-		return copyOfStack;
+
+			if (itemstack1.isEmpty()) {
+				slot.putStack(ItemStack.EMPTY);
+			} else {
+				slot.onSlotChanged();
+			}
+
+			if (itemstack1.getCount() == itemstack.getCount()) {
+				return ItemStack.EMPTY;
+			}
+
+			slot.onTake(playerIn, itemstack1);
+		}
+		return itemstack;
 	}
 
 	@Override

--- a/src/main/java/com/theundertaker11/geneticsreborn/blocks/cloningmachine/ContainerCloningMachine.java
+++ b/src/main/java/com/theundertaker11/geneticsreborn/blocks/cloningmachine/ContainerCloningMachine.java
@@ -68,6 +68,45 @@ public class ContainerCloningMachine extends Container {
 		return tileInventory.isUseableByPlayer(player);
 	}
 
+
+	@Override
+	public ItemStack transferStackInSlot(EntityPlayer playerIn, int index){
+		ItemStack itemstack = ItemStack.EMPTY;
+		Slot slot = this.inventorySlots.get(index);
+
+		if(slot != null && slot.getHasStack()){ //Checks that slot is valid and has items in it.
+			ItemStack itemstack1 = slot.getStack();
+			itemstack = itemstack1.copy();
+			if(index <= 35){
+				if(slot.getStack().getItem()== GRItems.OrganicMatter){
+					if (!this.mergeItemStack(slot.getStack(), 36, 37, false)) {
+						this.mergeItemStack(slot.getStack(), 36, 37,false);
+						return ItemStack.EMPTY;
+					}
+					else{
+						return itemstack;
+					}
+				}
+			} else if (!this.mergeItemStack(itemstack1, 0, 37, false)) {
+				return ItemStack.EMPTY;
+			}
+
+			if (itemstack1.isEmpty()) {
+				slot.putStack(ItemStack.EMPTY);
+			} else {
+				slot.onSlotChanged();
+			}
+
+			if (itemstack1.getCount() == itemstack.getCount()) {
+				return ItemStack.EMPTY;
+			}
+
+			slot.onTake(playerIn, itemstack1);
+		}
+		return itemstack;
+	}
+
+	/* Original GeneticsReborn code
 	@Override
 	public ItemStack transferStackInSlot(EntityPlayer player, int sourceSlotIndex) {
 		Slot slot = (Slot) this.inventorySlots.get(sourceSlotIndex);
@@ -97,7 +136,7 @@ public class ContainerCloningMachine extends Container {
 		} else return ItemStack.EMPTY;
 		return copyOfStack;
 	}
-
+*/
 	@Override
 	public void detectAndSendChanges() {
 		super.detectAndSendChanges();

--- a/src/main/java/com/theundertaker11/geneticsreborn/blocks/dnadecrypter/ContainerDNADecrypter.java
+++ b/src/main/java/com/theundertaker11/geneticsreborn/blocks/dnadecrypter/ContainerDNADecrypter.java
@@ -70,33 +70,40 @@ public class ContainerDNADecrypter extends Container {
 	}
 
 	@Override
-	public ItemStack transferStackInSlot(EntityPlayer player, int sourceSlotIndex) {
-		Slot slot = (Slot) this.inventorySlots.get(sourceSlotIndex);
-		if (slot == null || !slot.getHasStack()) return ItemStack.EMPTY;
-		if (tileInventory.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, EnumFacing.UP) == null)
-			return ItemStack.EMPTY;
-		IItemHandler input = tileInventory.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, EnumFacing.UP);
+	public ItemStack transferStackInSlot(EntityPlayer playerIn, int index){
+		ItemStack itemstack = ItemStack.EMPTY;
+		Slot slot = this.inventorySlots.get(index);
 
-		ItemStack sourceStack = slot.getStack();
-		ItemStack copyOfStack = sourceStack.copy();
-
-		if (sourceSlotIndex >= VANILLA_FIRST_SLOT_INDEX && sourceSlotIndex < VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT) {
-			if (sourceStack.getItem() == GRItems.DNAHelix && sourceStack.getTagCompound() != null && !ModUtils.getTagCompound(sourceStack).hasKey("gene")) {
-				if (input.insertItem(0, sourceStack, true).isEmpty()) {
-					input.insertItem(0, sourceStack, false);
-					player.inventory.setInventorySlotContents(sourceSlotIndex, ItemStack.EMPTY);
-				} else if (input.insertItem(0, sourceStack, true).getCount() == sourceStack.getCount()) {
-					return ItemStack.EMPTY;
-				} else {
-					player.inventory.setInventorySlotContents(sourceSlotIndex, input.insertItem(0, sourceStack, false));
+		if(slot != null && slot.getHasStack()){ //Checks that slot is valid and has items in it.
+			ItemStack itemstack1 = slot.getStack();
+			itemstack = itemstack1.copy();
+			if(index <= 35){
+				if(itemstack1.getItem() == GRItems.DNAHelix && itemstack1.getTagCompound() != null && !ModUtils.getTagCompound(itemstack1).hasKey("gene")){
+					if (!this.mergeItemStack(slot.getStack(), 36, 37, false)) {
+						this.mergeItemStack(slot.getStack(), 36, 37,false);
+						return ItemStack.EMPTY;
+					}
+					else{
+						return itemstack;
+					}
 				}
-			} else return ItemStack.EMPTY;
-		} else if (sourceSlotIndex == INPUT_SLOT_INDEX || sourceSlotIndex == OUTPUT_SLOT_INDEX) {
-			if (!this.mergeItemStack(sourceStack, VANILLA_FIRST_SLOT_INDEX, VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT, false)) {
+			} else if (!this.mergeItemStack(itemstack1, 0, 37, false)) {
 				return ItemStack.EMPTY;
 			}
-		} else return ItemStack.EMPTY;
-		return copyOfStack;
+
+			if (itemstack1.isEmpty()) {
+				slot.putStack(ItemStack.EMPTY);
+			} else {
+				slot.onSlotChanged();
+			}
+
+			if (itemstack1.getCount() == itemstack.getCount()) {
+				return ItemStack.EMPTY;
+			}
+
+			slot.onTake(playerIn, itemstack1);
+		}
+		return itemstack;
 	}
 
 	@Override

--- a/src/main/java/com/theundertaker11/geneticsreborn/blocks/dnaextractor/ContainerDNAExtractor.java
+++ b/src/main/java/com/theundertaker11/geneticsreborn/blocks/dnaextractor/ContainerDNAExtractor.java
@@ -73,34 +73,40 @@ public class ContainerDNAExtractor extends Container {
 	}
 
 	@Override
-	public ItemStack transferStackInSlot(EntityPlayer player, int sourceSlotIndex) {
-		Slot slot = (Slot) this.inventorySlots.get(sourceSlotIndex);
-		if (slot == null || !slot.getHasStack()) return ItemStack.EMPTY;
-		if (tileInventory.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, EnumFacing.UP) == null)
-			return ItemStack.EMPTY;
-		IItemHandler input = tileInventory.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, EnumFacing.UP);
+	public ItemStack transferStackInSlot(EntityPlayer playerIn, int index){
+		ItemStack itemstack = ItemStack.EMPTY;
+		Slot slot = this.inventorySlots.get(index);
 
-		ItemStack sourceStack = slot.getStack();
-		ItemStack copyOfStack = sourceStack.copy();
-
-		if (sourceSlotIndex >= VANILLA_FIRST_SLOT_INDEX && sourceSlotIndex < VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT) {
-			if (sourceStack.getItem() == GRItems.Cell)//TODO change here
-			{
-				if (input.insertItem(0, sourceStack, true).isEmpty()) {
-					input.insertItem(0, sourceStack, false);
-					player.inventory.setInventorySlotContents(sourceSlotIndex, ItemStack.EMPTY);
-				} else if (input.insertItem(0, sourceStack, true).getCount() == sourceStack.getCount()) {
-					return ItemStack.EMPTY;
-				} else {
-					player.inventory.setInventorySlotContents(sourceSlotIndex, input.insertItem(0, sourceStack, false));
+		if(slot != null && slot.getHasStack()){ //Checks that slot is valid and has items in it.
+			ItemStack itemstack1 = slot.getStack();
+			itemstack = itemstack1.copy();
+			if(index <= 35){
+				if(slot.getStack().getItem()== GRItems.Cell){
+					if (!this.mergeItemStack(slot.getStack(), 36, 37, false)) {
+						this.mergeItemStack(slot.getStack(), 36, 37,false);
+						return ItemStack.EMPTY;
+					}
+					else{
+						return itemstack;
+					}
 				}
-			} else return ItemStack.EMPTY;
-		} else if (sourceSlotIndex == INPUT_SLOT_INDEX || sourceSlotIndex == OUTPUT_SLOT_INDEX) {
-			if (!this.mergeItemStack(sourceStack, VANILLA_FIRST_SLOT_INDEX, VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT, false)) {
+			} else if (!this.mergeItemStack(itemstack1, 0, 37, false)) {
 				return ItemStack.EMPTY;
 			}
-		} else return ItemStack.EMPTY;
-		return copyOfStack;
+
+			if (itemstack1.isEmpty()) {
+				slot.putStack(ItemStack.EMPTY);
+			} else {
+				slot.onSlotChanged();
+			}
+
+			if (itemstack1.getCount() == itemstack.getCount()) {
+				return ItemStack.EMPTY;
+			}
+
+			slot.onTake(playerIn, itemstack1);
+		}
+		return itemstack;
 	}
 
 

--- a/src/main/java/com/theundertaker11/geneticsreborn/blocks/plasmidinfuser/ContainerPlasmidInfuser.java
+++ b/src/main/java/com/theundertaker11/geneticsreborn/blocks/plasmidinfuser/ContainerPlasmidInfuser.java
@@ -71,44 +71,49 @@ public class ContainerPlasmidInfuser extends Container {
 	}
 
 	@Override
-	public ItemStack transferStackInSlot(EntityPlayer player, int sourceSlotIndex) {
-		Slot slot = (Slot) this.inventorySlots.get(sourceSlotIndex);
-		if (slot == null || !slot.getHasStack()) return ItemStack.EMPTY;
-		if (tileInventory.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, EnumFacing.UP) == null)
-			return ItemStack.EMPTY;
-		IItemHandler input = tileInventory.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, EnumFacing.UP);
-		IItemHandler output = tileInventory.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, EnumFacing.DOWN);
+	public ItemStack transferStackInSlot(EntityPlayer playerIn, int index){
+		ItemStack itemstack = ItemStack.EMPTY;
+		Slot slot = this.inventorySlots.get(index);
 
-		ItemStack sourceStack = slot.getStack();
-		ItemStack copyOfStack = sourceStack.copy();
-
-		if (sourceSlotIndex >= VANILLA_FIRST_SLOT_INDEX && sourceSlotIndex < VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT) {
-			if (sourceStack.getItem() == GRItems.DNAHelix) {
-				if (input.insertItem(0, sourceStack, true).isEmpty()) {
-					input.insertItem(0, sourceStack, false);
-					player.inventory.setInventorySlotContents(sourceSlotIndex, ItemStack.EMPTY);
-				} else if (input.insertItem(0, sourceStack, true).getCount() == sourceStack.getCount()) {
-					return ItemStack.EMPTY;
-				} else {
-					player.inventory.setInventorySlotContents(sourceSlotIndex, input.insertItem(0, sourceStack, false));
+		if(slot != null && slot.getHasStack()){ //Checks that slot is valid and has items in it.
+			ItemStack itemstack1 = slot.getStack();
+			itemstack = itemstack1.copy();
+			if(index <= 35){
+				if(slot.getStack().getItem()== GRItems.DNAHelix){
+					if (!this.mergeItemStack(slot.getStack(), 36, 37, false)) {
+						this.mergeItemStack(slot.getStack(), 36, 37,false);
+						return ItemStack.EMPTY;
+					}
+					else{
+						return itemstack;
+					}
 				}
-			}
-			if (sourceStack.getItem() == GRItems.Plasmid) {
-				if (output.insertItem(0, sourceStack, true) == ItemStack.EMPTY) {
-					output.insertItem(0, sourceStack, false);
-					player.inventory.setInventorySlotContents(sourceSlotIndex, ItemStack.EMPTY);
-				} else if (output.insertItem(0, sourceStack, true).getCount() == sourceStack.getCount()) {
-					return ItemStack.EMPTY;
-				} else {
-					player.inventory.setInventorySlotContents(sourceSlotIndex, output.insertItem(0, sourceStack, false));
+				if(slot.getStack().getItem() == GRItems.Plasmid){
+					if (!this.mergeItemStack(slot.getStack(), 37, 38, false)) {
+						this.mergeItemStack(slot.getStack(), 37, 38,false);
+						return ItemStack.EMPTY;
+					}
+					else{
+						return itemstack;
+					}
 				}
-			} else return ItemStack.EMPTY;
-		} else if (sourceSlotIndex == INPUT_SLOT_INDEX || sourceSlotIndex == OUTPUT_SLOT_INDEX) {
-			if (!this.mergeItemStack(sourceStack, VANILLA_FIRST_SLOT_INDEX, VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT, false)) {
+			} else if (!this.mergeItemStack(itemstack1, 0, 37, false)) {
 				return ItemStack.EMPTY;
 			}
-		} else return ItemStack.EMPTY;
-		return copyOfStack;
+
+			if (itemstack1.isEmpty()) {
+				slot.putStack(ItemStack.EMPTY);
+			} else {
+				slot.onSlotChanged();
+			}
+
+			if (itemstack1.getCount() == itemstack.getCount()) {
+				return ItemStack.EMPTY;
+			}
+
+			slot.onTake(playerIn, itemstack1);
+		}
+		return itemstack;
 	}
 
 	@Override

--- a/src/main/java/com/theundertaker11/geneticsreborn/blocks/plasmidinjector/ContainerPlasmidInjector.java
+++ b/src/main/java/com/theundertaker11/geneticsreborn/blocks/plasmidinjector/ContainerPlasmidInjector.java
@@ -69,47 +69,54 @@ public class ContainerPlasmidInjector extends Container {
 	}
 
 	@Override
-	public ItemStack transferStackInSlot(EntityPlayer player, int sourceSlotIndex) {
-		Slot slot = (Slot) this.inventorySlots.get(sourceSlotIndex);
-		if (slot == null || !slot.getHasStack()) return ItemStack.EMPTY;
-		if (tileInventory.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, EnumFacing.UP) == null)
-			return ItemStack.EMPTY;
-		IItemHandler input = tileInventory.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, EnumFacing.UP);
-		IItemHandler output = tileInventory.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, EnumFacing.DOWN);
+	public ItemStack transferStackInSlot(EntityPlayer playerIn, int index){
+		ItemStack itemstack = ItemStack.EMPTY;
+		Slot slot = this.inventorySlots.get(index);
 
-		ItemStack sourceStack = slot.getStack();
-		ItemStack copyOfStack = sourceStack.copy();
+		if(slot != null && slot.getHasStack()){ //Checks that slot is valid and has items in it.
+			ItemStack itemstack1 = slot.getStack();
+			itemstack = itemstack1.copy();
+			if(index <= 35){
+				if(slot.getStack().getItem()== GRItems.Plasmid || slot.getStack().getItem() == GRItems.AntiPlasmid){
+					if (itemstack1.getTagCompound() != null && itemstack1.getTagCompound().getInteger("num") == itemstack1.getTagCompound().getInteger("numNeeded")) {
+						if (!this.mergeItemStack(slot.getStack(), 36, 37, false)) {
+							this.mergeItemStack(slot.getStack(), 36, 37, false);
+							return ItemStack.EMPTY;
+						} else {
+							return itemstack;
+						}
+					}
+					else return ItemStack.EMPTY;
+				}
+				if(slot.getStack().getItem() == GRItems.GlassSyringe ) {
+					if (itemstack1.getTagCompound().getInteger("pure") == 1) {
+						if (!this.mergeItemStack(slot.getStack(), 37, 38, false)) {
+							this.mergeItemStack(slot.getStack(), 37, 38, false);
+							return ItemStack.EMPTY;
+						} else {
+							return itemstack;
+						}
+					}
+				}
+				else return ItemStack.EMPTY;
 
-		if (sourceSlotIndex >= VANILLA_FIRST_SLOT_INDEX && sourceSlotIndex < VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT) {
-			if (sourceStack.getItem() == GRItems.Plasmid || sourceStack.getItem() == GRItems.AntiPlasmid) {
-				if (sourceStack.getTagCompound() != null && sourceStack.getTagCompound().getInteger("num") == sourceStack.getTagCompound().getInteger("numNeeded")) {
-					if (input.insertItem(0, sourceStack, true).isEmpty()) {
-						input.insertItem(0, sourceStack, false);
-						player.inventory.setInventorySlotContents(sourceSlotIndex, ItemStack.EMPTY);
-					} else if (input.insertItem(0, sourceStack, true).getCount() == sourceStack.getCount()) {
-						return ItemStack.EMPTY;
-					} else {
-						player.inventory.setInventorySlotContents(sourceSlotIndex, input.insertItem(0, sourceStack, false));
-					}
-				} else return ItemStack.EMPTY;
-			} else if ((sourceStack.getItem() == GRItems.GlassSyringe || sourceStack.getItem() == GRItems.MetalSyringe) && sourceStack.getTagCompound() != null && sourceStack.getItemDamage() == 1) {
-				if (sourceStack.getTagCompound().getBoolean("pure")) {
-					if (output.insertItem(0, sourceStack, true).isEmpty()) {
-						output.insertItem(0, sourceStack, false);
-						player.inventory.setInventorySlotContents(sourceSlotIndex, ItemStack.EMPTY);
-					} else if (output.insertItem(0, sourceStack, true).isEmpty() == sourceStack.isEmpty()) {
-						return ItemStack.EMPTY;
-					} else {
-						player.inventory.setInventorySlotContents(sourceSlotIndex, output.insertItem(0, sourceStack, false));
-					}
-				} else return ItemStack.EMPTY;
-			} else return ItemStack.EMPTY;
-		} else if (sourceSlotIndex == INPUT_SLOT_INDEX || sourceSlotIndex == OUTPUT_SLOT_INDEX) {
-			if (!this.mergeItemStack(sourceStack, VANILLA_FIRST_SLOT_INDEX, VANILLA_FIRST_SLOT_INDEX + VANILLA_SLOT_COUNT, false)) {
+			} else if (!this.mergeItemStack(itemstack1, 0, 37, false)) {
 				return ItemStack.EMPTY;
 			}
-		} else return ItemStack.EMPTY;
-		return copyOfStack;
+
+			if (itemstack1.isEmpty()) {
+				slot.putStack(ItemStack.EMPTY);
+			} else {
+				slot.onSlotChanged();
+			}
+
+			if (itemstack1.getCount() == itemstack.getCount()) {
+				return ItemStack.EMPTY;
+			}
+
+			slot.onTake(playerIn, itemstack1);
+		}
+		return itemstack;
 	}
 
 	@Override


### PR DESCRIPTION
Fixes TheUnderTaker11/GeneticsReborn#67 and TheUnderTaker11/GeneticsReborn#70

From my testing I have found that all blocks besides the Coal Generator needed a major revamp of the transferStackInSlot method to end the duplication bug that was occurring from the old method.