### PR TITLE
fix issue #184 and added a new command 'gene list'

### DIFF
--- a/src/main/java/com/theundertaker11/geneticsreborn/commands/CommandAdd.java
+++ b/src/main/java/com/theundertaker11/geneticsreborn/commands/CommandAdd.java
@@ -1,12 +1,9 @@
 package com.theundertaker11.geneticsreborn.commands;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import com.theundertaker11.geneticsreborn.Reference;
 import com.theundertaker11.geneticsreborn.api.capability.genes.EnumGenes;
-import com.theundertaker11.geneticsreborn.api.capability.genes.Genes;
 import com.theundertaker11.geneticsreborn.api.capability.genes.IGenes;
 import com.theundertaker11.geneticsreborn.event.PlayerTickEvent;
 import com.theundertaker11.geneticsreborn.util.ModUtils;
@@ -16,7 +13,6 @@ import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.WrongUsageException;
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextComponentString;
@@ -30,52 +26,54 @@ public class CommandAdd extends CommandBase {
 
 	@Override
 	public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
-		EntityLivingBase entity;
+		List<EntityLivingBase> entities;
 		IGenes genes;
-        if (args.length >= 2) {
-        	if ("@p".equals(args[0])) {
-        		entity = (EntityLivingBase) sender.getCommandSenderEntity();
-        	} else {
-        		entity = server.getPlayerList().getPlayerByUsername(args[0]);
-        	}
-        	if (entity == null) throw new CommandException("Player not found: "+args[0]);
+		int count = 0;
 
-        	if ("all".equals(args[1])) {
-    			genes = ModUtils.getIGenes(entity);
-    			for (EnumGenes g : EnumGenes.values()) 
-    				if (!g.isNegative() && !genes.hasGene(g)) {
-    					PlayerTickEvent.geneChanged(entity, g, true);
-    					genes.addGene(g);
-    				}
-    			sender.sendMessage(new TextComponentString("Added all genes to " + sender.getName()));
-        	} else {
-      			genes = ModUtils.getIGenes(entity);
-            	for (int i=1; i< args.length;i++) {
-            		EnumGenes gene = EnumGenes.fromGeneName(args[i]);
-            		if (gene == null) throw new CommandException("No gene found named: "+args[i]);
-           			if (!genes.hasGene(gene)) {
-           				genes.addGene(gene);
-                   		PlayerTickEvent.geneChanged(entity, gene, true);
-           			}
-        			sender.sendMessage(new TextComponentString(String.format("Added %d genes to %s",  args.length-1, sender.getName())));
-            	}
-        	}
-        } else 
-            throw new WrongUsageException(this.getUsage(sender));
+		if (args.length >= 2) {
+			entities = CommandTree.getTargets(server, args[0], sender);
+			for(EntityLivingBase entity : entities) {
+				genes = ModUtils.getIGenes(entity);
+				if ("all".equals(args[1])) {
+					for (EnumGenes g : EnumGenes.values())
+						if (!g.isNegative() && !genes.hasGene(g)) {
+							PlayerTickEvent.geneChanged(entity, g, true);
+							genes.addGene(g);
+						}
+					sender.sendMessage(new TextComponentString("Added all genes to " + entity.getName()));
+					if(sender.getName() != entity.getName()) entity.sendMessage(new TextComponentString("Added all genes to you"));
+				} else {
+					for (int i = 1; i < args.length; i++) {
+						EnumGenes gene = EnumGenes.fromGeneName(args[i]);
+						if (gene == null) {
+							sender.sendMessage(new TextComponentString("No gene found named " + args[i] + ", so not added"));
+						}else if (!genes.hasGene(gene)) {
+							PlayerTickEvent.geneChanged(entity, gene, true);
+							genes.addGene(gene);
+							count++;
+						}
+					}
+					sender.sendMessage(new TextComponentString(String.format("Added %d genes to %s",  count, entity.getName())));
+					if(sender.getName() != entity.getName()) entity.sendMessage(new TextComponentString(String.format("Added %d genes to you",  count)));
+				}
+			}
+		} else {
+			throw new WrongUsageException(this.getUsage(sender));
+		}
 	}
 
 	@Override
 	public String getUsage(ICommandSender sender) {
 		return "/" + Reference.MODID + " add <player> [ all | <gene_name>...]";
 	}
-	
+
 	@Override
 	public int getRequiredPermissionLevel() {
 		return 2;
 	}
-	
+
 	@Override
 	public List<String> getTabCompletions(MinecraftServer server, ICommandSender sender, String[] args,	BlockPos targetPos) {
-		return CommandTree.getTabCompletions(server, args);
+		return CommandTree.getTabCompletions(server, args, this.getName());
 	}
 }

--- a/src/main/java/com/theundertaker11/geneticsreborn/commands/CommandAdd.java
+++ b/src/main/java/com/theundertaker11/geneticsreborn/commands/CommandAdd.java
@@ -45,13 +45,15 @@ public class CommandAdd extends CommandBase {
 				} else {
 					for (int i = 1; i < args.length; i++) {
 						EnumGenes gene = EnumGenes.fromGeneName(args[i]);
-						if (gene == null) {
-							sender.sendMessage(new TextComponentString("No gene found named " + args[i] + ", so not added"));
-						}else if (!genes.hasGene(gene)) {
+						if (gene == null) //if no gene with name requested
+							sender.sendMessage(new TextComponentString("No gene found called " + args[i] + ", so not added"));
+						else if (!genes.hasGene(gene)) { //add gene
 							PlayerTickEvent.geneChanged(entity, gene, true);
 							genes.addGene(gene);
 							count++;
 						}
+						else //if player already has requested gene
+							sender.sendMessage(new TextComponentString(String.format("%s already has %s, so not added", entity.getName(), args[i])));
 					}
 					sender.sendMessage(new TextComponentString(String.format("Added %d genes to %s",  count, entity.getName())));
 					if(sender.getName() != entity.getName()) entity.sendMessage(new TextComponentString(String.format("Added %d genes to you",  count)));

--- a/src/main/java/com/theundertaker11/geneticsreborn/commands/CommandList.java
+++ b/src/main/java/com/theundertaker11/geneticsreborn/commands/CommandList.java
@@ -1,0 +1,60 @@
+package com.theundertaker11.geneticsreborn.commands;
+
+import java.util.List;
+
+import com.theundertaker11.geneticsreborn.Reference;
+import com.theundertaker11.geneticsreborn.api.capability.genes.EnumGenes;
+import com.theundertaker11.geneticsreborn.util.ModUtils;
+
+import net.minecraft.command.CommandBase;
+import net.minecraft.command.CommandException;
+import net.minecraft.command.ICommandSender;
+import net.minecraft.command.WrongUsageException;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.text.TextComponentString;
+
+public class CommandList extends CommandBase {
+
+    @Override
+    public String getName() {
+        return "list";
+    }
+
+    @Override
+    public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
+        List<EntityLivingBase> entities;
+
+        if (args.length == 1) {
+            entities = CommandTree.getTargets(server, args[0], sender);
+
+            for(EntityLivingBase entity : entities) {
+                List<EnumGenes> genes = ModUtils.getIGenes(entity).getGeneList();
+                String msg = String.format("Player %s has %d genes: ", entity.getName(), genes.size());
+                for(EnumGenes gene : genes) {
+                    if (gene != genes.get(0)) msg += ", ";
+                    msg += gene.getDescription();
+                }
+                sender.sendMessage(new TextComponentString(msg));
+            }
+        } else {
+            throw new WrongUsageException(this.getUsage(sender));
+        }
+    }
+
+    @Override
+    public String getUsage(ICommandSender sender) {
+        return "/" + Reference.MODID + " list <player>";
+    }
+
+    @Override
+    public int getRequiredPermissionLevel() {
+        return 2;
+    }
+
+    @Override
+    public List<String> getTabCompletions(MinecraftServer server, ICommandSender sender, String[] args,	BlockPos targetPos) {
+        return CommandTree.getTabCompletions(server, args, this.getName());
+    }
+}

--- a/src/main/java/com/theundertaker11/geneticsreborn/commands/CommandRemove.java
+++ b/src/main/java/com/theundertaker11/geneticsreborn/commands/CommandRemove.java
@@ -26,43 +26,44 @@ public class CommandRemove extends CommandBase {
 
 	@Override
 	public void execute(MinecraftServer server, ICommandSender sender, String[] args) throws CommandException {
-        if (args.length >= 2) {
-        	EntityLivingBase entity;
-        	IGenes genes;
-        	if ("@p".equals(args[0])) {
-        		entity = (EntityLivingBase) sender.getCommandSenderEntity();
-        	} else {
-        		entity = server.getPlayerList().getPlayerByUsername(args[0]);
-        	}
-        	if (entity == null) throw new CommandException("Player not found: "+args[0]);
+		List<EntityLivingBase> entities;
+		IGenes genes;
+		int count = 0;
 
-        	if ("all".equals(args[1])) {
-    			genes = ModUtils.getIGenes(entity);
-            	for (EnumGenes g : genes.getGeneList()) 
-            		if (genes.hasGene(g)) PlayerTickEvent.geneChanged(entity, g, false);
-    			genes.removeAllGenes();
-    			sender.sendMessage(new TextComponentString("Removed all genes from " + sender.getName()));
-        	} else {
-    			genes = ModUtils.getIGenes(entity);
-            	for (int i=1; i< args.length;i++) {
-            		EnumGenes gene = EnumGenes.fromGeneName(args[i]);
-            		if (gene == null) throw new CommandException("No gene found named: "+args[i]);
-            		if (genes.hasGene(gene)) {
-                		genes.removeGene(gene);
-            			PlayerTickEvent.geneChanged(entity, gene, false);
-            		}
-        			sender.sendMessage(new TextComponentString(String.format("Removed %d genes from %s",  args.length-1, sender.getName())));
-            	}
-        	}
-        } else 
-            throw new WrongUsageException(this.getUsage(sender));
+		if (args.length >= 2) {
+			entities = CommandTree.getTargets(server, args[0], sender);
+			for(EntityLivingBase entity : entities) {
+				genes = ModUtils.getIGenes(entity);
+				if ("all".equals(args[1])) {
+					for (EnumGenes g : genes.getGeneList())
+						PlayerTickEvent.geneChanged(entity, g, false);
+					genes.removeAllGenes();
+					sender.sendMessage(new TextComponentString("Removed all genes from " + entity.getName()));
+					if(sender.getName() != entity.getName()) entity.sendMessage(new TextComponentString("Removed all genes from you"));
+				} else {
+					for (int i = 1; i < args.length; i++) {
+						EnumGenes gene = EnumGenes.fromGeneName(args[i]);
+						if (gene == null){
+							sender.sendMessage(new TextComponentString("No gene found named " + args[i] + ", so not removed"));
+						} else if (genes.hasGene(gene)) {
+							genes.removeGene(gene);
+							PlayerTickEvent.geneChanged(entity, gene, false);
+							count++;
+						}
+					}
+					sender.sendMessage(new TextComponentString(String.format("Removed %d genes from %s", count, entity.getName())));
+					if(sender.getName() != entity.getName()) entity.sendMessage(new TextComponentString(String.format("Removed %d genes from you",  count)));
+				}
+			}
+		} else
+			throw new WrongUsageException(this.getUsage(sender));
 	}
 
 	@Override
 	public String getUsage(ICommandSender sender) {
 		return "/" + Reference.MODID + " remove <player> all | <gene_name>...";
 	}
-	
+
 	@Override
 	public int getRequiredPermissionLevel() {
 		return 2;
@@ -70,7 +71,7 @@ public class CommandRemove extends CommandBase {
 
 	@Override
 	public List<String> getTabCompletions(MinecraftServer server, ICommandSender sender, String[] args,	BlockPos targetPos) {
-		return CommandTree.getTabCompletions(server, args);
+		return CommandTree.getTabCompletions(server, args, this.getName());
 	}
 
 }

--- a/src/main/java/com/theundertaker11/geneticsreborn/commands/CommandRemove.java
+++ b/src/main/java/com/theundertaker11/geneticsreborn/commands/CommandRemove.java
@@ -43,13 +43,15 @@ public class CommandRemove extends CommandBase {
 				} else {
 					for (int i = 1; i < args.length; i++) {
 						EnumGenes gene = EnumGenes.fromGeneName(args[i]);
-						if (gene == null){
-							sender.sendMessage(new TextComponentString("No gene found named " + args[i] + ", so not removed"));
-						} else if (genes.hasGene(gene)) {
+						if (gene == null) //if no gene with name requested
+							sender.sendMessage(new TextComponentString("No gene found called " + args[i] + ", so not removed"));
+						else if (genes.hasGene(gene)) { //remove gene
 							genes.removeGene(gene);
 							PlayerTickEvent.geneChanged(entity, gene, false);
 							count++;
 						}
+						else //if player doesn't have requested gene
+							sender.sendMessage(new TextComponentString(String.format("%s doesn't have %s, so not removed", entity.getName(), args[i])));
 					}
 					sender.sendMessage(new TextComponentString(String.format("Removed %d genes from %s", count, entity.getName())));
 					if(sender.getName() != entity.getName()) entity.sendMessage(new TextComponentString(String.format("Removed %d genes from you",  count)));

--- a/src/main/java/com/theundertaker11/geneticsreborn/commands/CommandTree.java
+++ b/src/main/java/com/theundertaker11/geneticsreborn/commands/CommandTree.java
@@ -2,6 +2,7 @@ package com.theundertaker11.geneticsreborn.commands;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 import java.util.StringJoiner;
 
 import com.theundertaker11.geneticsreborn.Reference;
@@ -10,9 +11,10 @@ import com.theundertaker11.geneticsreborn.api.capability.genes.EnumGenes;
 import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommand;
 import net.minecraft.command.ICommandSender;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.text.TextComponentString;
 import net.minecraftforge.server.command.CommandTreeBase;
 
@@ -26,6 +28,7 @@ public class CommandTree extends CommandTreeBase {
     public CommandTree() {        
         this.addSubcommand(new CommandAdd());
         this.addSubcommand(new CommandRemove());
+        this.addSubcommand(new CommandList());
     }    
     
 	@Override
@@ -58,22 +61,49 @@ public class CommandTree extends CommandTreeBase {
         return aliases;
     }	
     
-	public static List<String> getTabCompletions(MinecraftServer server, String[] args) {
+	public static List<String> getTabCompletions(MinecraftServer server, String[] args, String cmd) {
 		List<String> result = new ArrayList<String>();
-		
-		if (args.length == 1) {
-			String match = args[0].toLowerCase();
-			if ("".equals(match)) result.add("@p");
+
+        String match = args[args.length - 1].toLowerCase();
+		if (args.length == 1) { //argument of what player/players to operate on
+			if("@p".startsWith(match)) result.add("@p");
+			if("@r".startsWith(match)) result.add("@r");
+			if("@a".startsWith(match)) result.add("@a");
+
 			for (EntityPlayer p : server.getPlayerList().getPlayers()) 
-				if ("".equals(match) || p.getName().toLowerCase().startsWith(match)) result.add(p.getName());										
-		} else if (args.length == 2) {
-			String match = args[1].toLowerCase();
-			if ("".equals(match) ||"all".startsWith(match)) result.add("all");
+				if (p.getName().toLowerCase().startsWith(match)) result.add(p.getName());
+		} else if (args.length >= 2 && !cmd.equals("list") && !args[1].equals("all")) { //only for add/remove commands
+			if (args.length == 2 && ("".equals(match) || "all".startsWith(match))) result.add("all");
 			for (EnumGenes g : EnumGenes.values())
-				if ("".equals(match) || g.name().toLowerCase().startsWith(match)) result.add(g.name());
+				if (g.name().toLowerCase().startsWith(match)) result.add(g.name());
 		}
 		
 		return result;
 	}
-    
+
+	public static List<EntityLivingBase> getTargets(MinecraftServer server, String arg, ICommandSender sender) throws CommandException{
+        List<EntityLivingBase> targets = new ArrayList<>();
+        List<EntityPlayerMP> temp;
+        Random rand = new Random();
+        switch(arg) { //make list of players to act upon
+            case "@p": //select executing player
+                targets.add((EntityLivingBase) sender.getCommandSenderEntity());
+                if(targets.get(0) == null) throw new CommandException("Can't get executing entity");
+                break;
+            case "@a": //select all players
+                for(EntityLivingBase player : server.getPlayerList().getPlayers()) {targets.add(player);}
+                if(targets.size() == 0) throw new CommandException("No player found"); //CHECK LATER
+                break;
+            case "@r": //select a random player
+                temp = server.getPlayerList().getPlayers();
+                if(temp.size() == 0) throw new CommandException("No player found");
+                targets.add((EntityLivingBase)temp.get(rand.nextInt(temp.size())));
+                break;
+            default: //select player of given name
+                targets.add(server.getPlayerList().getPlayerByUsername(arg));
+                if(targets.get(0) == null) throw new CommandException("Player not found: " + arg);
+                break;
+        }
+        return targets;
+    }
 }

--- a/src/main/java/com/theundertaker11/geneticsreborn/commands/CommandTree.java
+++ b/src/main/java/com/theundertaker11/geneticsreborn/commands/CommandTree.java
@@ -92,7 +92,7 @@ public class CommandTree extends CommandTreeBase {
                 break;
             case "@a": //select all players
                 for(EntityLivingBase player : server.getPlayerList().getPlayers()) {targets.add(player);}
-                if(targets.size() == 0) throw new CommandException("No player found"); //CHECK LATER
+                if(targets.size() == 0) throw new CommandException("No player found");
                 break;
             case "@r": //select a random player
                 temp = server.getPlayerList().getPlayers();


### PR DESCRIPTION
Edit: Fixes issue #184, a bit more polish to commands, added 'gene list' command
changelog:
* gene add/remove now prints correctly the player it is acting upon.
* Added @\a (affect all players) and @\r (affect a random player) selectors it addition to @\p (added \ here because github messes with it).
* Autocomplete is a bit smarter now, it can autocomplete several genes instead of just the first one
* Added a new command, 'list', that prints the genes a player has.
* in gene add/remove, it shows how many genes were actually added/removed, instead of the amount of genes supplied to command. It now also prints a warning and keeps running instead of throwing an exception if a gene that doesn't exist is given.
* players will now be notified when someone add/removes genes from them.